### PR TITLE
GetRawValue関連の処理

### DIFF
--- a/Assets/LucidInput/Runtime/Controls/AxisCompositeControl.cs
+++ b/Assets/LucidInput/Runtime/Controls/AxisCompositeControl.cs
@@ -44,6 +44,7 @@ namespace AnnulusGames.LucidTools.InputSystem
             negativeButton.Update();
 
             UpdateValue();
+            UpdateRawValue();
 
             timeLastUpdate = Time.realtimeSinceStartup;
         }
@@ -61,6 +62,14 @@ namespace AnnulusGames.LucidTools.InputSystem
             else currentValue = valuePositive > valueNegative ? valuePositive : -valueNegative;
         }
 
+        private void UpdateRawValue()
+        {
+            currentRawValue = 0;
+
+            currentRawValue += positiveButton.GetButton() ? 1 : 0;
+            currentRawValue -= negativeButton.GetButton() ? 1 : 0;
+        }
+
         public override float GetValue()
         {
             return currentValue;
@@ -68,7 +77,7 @@ namespace AnnulusGames.LucidTools.InputSystem
 
         public override float GetValueRaw()
         {
-            return 
+            return currentRawValue;
         }
     }
 

--- a/Assets/LucidInput/Runtime/Controls/AxisCompositeControl.cs
+++ b/Assets/LucidInput/Runtime/Controls/AxisCompositeControl.cs
@@ -19,6 +19,7 @@ namespace AnnulusGames.LucidTools.InputSystem
         private float valuePositive;
         private float valueNegative;
         private float currentValue;
+        private float currentRawValue;
 
         private float timeLastUpdate;
 
@@ -42,8 +43,14 @@ namespace AnnulusGames.LucidTools.InputSystem
             positiveButton.Update();
             negativeButton.Update();
 
-            float deltaTime = Time.realtimeSinceStartup - timeLastUpdate;
+            UpdateValue();
 
+            timeLastUpdate = Time.realtimeSinceStartup;
+        }
+
+        private void UpdateValue()
+        {
+            float deltaTime = Time.realtimeSinceStartup - timeLastUpdate;
             valuePositive += ((positiveButton.GetButton() ? 1 : 0) * 2f - 1f) * deltaTime * AXIS_SENSITIVITY;
             valuePositive = Math.Clamp(valuePositive, 0f, 1f);
             valueNegative += ((negativeButton.GetButton() ? 1 : 0) * 2f - 1f) * deltaTime * AXIS_SENSITIVITY;
@@ -52,13 +59,16 @@ namespace AnnulusGames.LucidTools.InputSystem
             if (currentValue >= 1) currentValue = valuePositive;
             else if (currentValue <= -1) currentValue = -valueNegative;
             else currentValue = valuePositive > valueNegative ? valuePositive : -valueNegative;
-
-            timeLastUpdate = Time.realtimeSinceStartup;
         }
 
         public override float GetValue()
         {
             return currentValue;
+        }
+
+        public override float GetValueRaw()
+        {
+            return 
         }
     }
 

--- a/Assets/LucidInput/Runtime/Controls/AxisControl.cs
+++ b/Assets/LucidInput/Runtime/Controls/AxisControl.cs
@@ -16,7 +16,7 @@ namespace AnnulusGames.LucidTools.InputSystem
             return getValue();
         }
 
-        public float GetValueRaw()
+        public virtual float GetValueRaw()
         {
             float value = GetValue();
             return value == 0f ? 0f : (value > 0f ? 1f : -1f);

--- a/Assets/LucidInput/Runtime/LucidInput.cs
+++ b/Assets/LucidInput/Runtime/LucidInput.cs
@@ -470,7 +470,7 @@ namespace AnnulusGames.LucidTools.InputSystem
 
                 foreach (var axisInput in pair.Value)
                 {
-                    if (Math.Abs(result) < Math.Abs(axisInput.GetValue()))
+                    if (Math.Abs(result) < Math.Abs(axisInput.GetValueRaw()))
                     {
                         result = axisInput.GetValueRaw();
                     }


### PR DESCRIPTION
## 問題点
- `LucidInput.GetAxisRaw`を使用してキー入力で値をとると、キーを離しても実際の値に反映されるまで遅延があった
- "LucidInput"の473行目の条件式が間違ってた（コミット`8a8ace29479e0e3f729eba3130bbdbe7d62bb5ff`を参照）

## 変更点
- `AxisControl`内の`GetValueRaw`をvirtualメソッドに変更
- `AxisCompositeControl`内で`GetValueRaw`をオーバーライド
- `AxisCompositeControl`の可読性が下がることを考慮して`currentValue`と`currentRawValue`の更新をそれぞれの関数に切り出した